### PR TITLE
Sprint 7/WCAIR-55: Add Value Price Concern Prompt Template

### DIFF
--- a/includes/LLM/PromptBuilder.php
+++ b/includes/LLM/PromptBuilder.php
@@ -14,6 +14,7 @@ use WcAiReviewResponder\LLM\Prompts\Templates\PositiveWithCritiqueTemplate;
 use WcAiReviewResponder\LLM\Prompts\Templates\ProductMisunderstandingTemplate;
 use WcAiReviewResponder\LLM\Prompts\Templates\DefectiveProductTemplate;
 use WcAiReviewResponder\LLM\Prompts\Templates\ShippingIssueTemplate;
+use WcAiReviewResponder\LLM\Prompts\Templates\ValuePriceConcernTemplate;
 use WcAiReviewResponder\LLM\Prompts\Templates\PromptTemplateInterface;
 use WcAiReviewResponder\LLM\Prompts\ReviewContext;
 use WcAiReviewResponder\LLM\Prompts\TemplateType;
@@ -38,6 +39,7 @@ class PromptBuilder implements BuildPromptInterface {
 		'product_misunderstanding' => ProductMisunderstandingTemplate::class,
 		'defective_product'        => DefectiveProductTemplate::class,
 		'shipping_issue'           => ShippingIssueTemplate::class,
+		'value_price_concern'      => ValuePriceConcernTemplate::class,
 	);
 
 	/**

--- a/includes/LLM/Prompts/TemplateType.php
+++ b/includes/LLM/Prompts/TemplateType.php
@@ -22,4 +22,5 @@ enum TemplateType: string {
 	case PRODUCT_MISUNDERSTANDING = 'product_misunderstanding';
 	case DEFECTIVE_PRODUCT        = 'defective_product';
 	case SHIPPING_ISSUE           = 'shipping_issue';
+	case VALUE_PRICE_CONCERN      = 'value_price_concern';
 }

--- a/includes/LLM/Prompts/Templates/ValuePriceConcernTemplate.php
+++ b/includes/LLM/Prompts/Templates/ValuePriceConcernTemplate.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Value/Price Concern prompt template.
+ *
+ * @package WcAiReviewResponder
+ * @since   1.0.0
+ */
+
+namespace WcAiReviewResponder\LLM\Prompts\Templates;
+
+use WcAiReviewResponder\LLM\Prompts\ReviewContextInterface;
+
+/**
+ * Template for responding to reviews that question the product's value for its price.
+ */
+class ValuePriceConcernTemplate implements PromptTemplateInterface {
+	/**
+	 * Get the template prompt.
+	 *
+	 * @param ReviewContextInterface $context Review context object.
+	 * @return string The formatted prompt.
+	 */
+	public function get_prompt( ReviewContextInterface $context ): string {
+		$prompt  = 'Write a confident and reassuring reply to this review that questions the product\'s value for its price. ';
+		$prompt .= 'Acknowledge their concern about pricing and thank them for their honest feedback. ';
+		$prompt .= 'Justify the price by highlighting the product\'s superior quality, craftsmanship, and unique features that provide long-term value. ';
+		$prompt .= 'Offer to help them get the most value out of their purchase. ';
+		$prompt .= 'As a token of appreciation, provide a limited-time loyalty discount for their next purchase. ';
+		$prompt .= 'Maintain a professional and appreciative tone, reinforcing the brand\'s commitment to quality and customer value (4-5 sentences).';
+		$prompt .= "\n\nProduct: {$context->get_product_name()}";
+		$prompt .= "\nRating: {$context->get_formatted_rating()}";
+		$prompt .= "\nReview: {$context->get_comment()}";
+		$prompt .= "\n\nYour response:";
+
+		return $prompt;
+	}
+}


### PR DESCRIPTION
## Description
This PR adds a new prompt template for handling customer reviews that question the product's value for its price.

## Changes
- Add ValuePriceConcernTemplate class for handling value/price concern reviews
- Update PromptBuilder to include new template mapping
- Add VALUE_PRICE_CONCERN enum case to TemplateType
- Template focuses on justifying price through quality and offering loyalty discount

## Testing
- [x] Tests pass
- [x] Manual testing completed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)